### PR TITLE
Add delay logic

### DIFF
--- a/controller/mainCtrl.js
+++ b/controller/mainCtrl.js
@@ -37,8 +37,7 @@ class MainController {
 
         this.io.on('connection', socket => {
             console.log(new Date(Date.now())+", A consigner connected", socket.id);
-            socket.on('getConsignerIndex', (data, cb) => this.addCosigner(socket, cb));
-            socket.on('getDelay', (data, cb) => this.returnDelay(cb));
+            socket.on('getConsignerIndexAndDelay', (data, cb) => this.addCosigner(socket, cb));
             socket.on('disconnect', () => this.removeCosigner(socket));
             socket.on('getDepositAddress', (...args) => this.getDepositAddress.apply(this, [socket, ...args]));
             socket.on('getDepositHistory', (...args) => this.getDepositHistory.apply(this, [...args]));
@@ -51,11 +50,7 @@ class MainController {
     addCosigner(socket, cb){
         console.log("Adding cosigner");
         this.consignersArray.push(socket.id);
-        return cb(this.consignersArray.length-1);
-    }
-
-    returnDelay(cb) {
-        return cb(2 * (this.consignersArray.length-1));
+        return cb({index: this.consignersArray.length-1, delay: 2 * (this.consignersArray.length-1)});
     }
 
     removeCosigner(socket){

--- a/controller/mainCtrl.js
+++ b/controller/mainCtrl.js
@@ -37,7 +37,8 @@ class MainController {
 
         this.io.on('connection', socket => {
             console.log(new Date(Date.now())+", A consigner connected", socket.id);
-            socket.on('getConsignerIndex', (cb) => this.addCosigner(socket, cb));
+            socket.on('getConsignerIndex', (data, cb) => this.addCosigner(socket, cb));
+            socket.on('getDelay', (data, cb) => this.returnDelay(cb));
             socket.on('disconnect', () => this.removeCosigner(socket));
             socket.on('getDepositAddress', (...args) => this.getDepositAddress.apply(this, [socket, ...args]));
             socket.on('getDepositHistory', (...args) => this.getDepositHistory.apply(this, [...args]));
@@ -51,6 +52,10 @@ class MainController {
         console.log("Adding cosigner");
         this.consignersArray.push(socket.id);
         return cb(this.consignersArray.length-1);
+    }
+
+    returnDelay(cb) {
+        return cb(2 * (this.consignersArray.length-1));
     }
 
     removeCosigner(socket){


### PR DESCRIPTION
Add simple delay logic. But as I wrote in the DistributedCollective/FastBTC-confirmation-node#12, it is still cheatable. Solution imo would be to use a JWT system with which we could encrypt the delay. But maybe it is overcomplicating or we could add this later. Not so important?