### PR TITLE
create bech32 addresses for those users that do not have bech32 yet

### DIFF
--- a/controller/mainCtrl.js
+++ b/controller/mainCtrl.js
@@ -61,7 +61,7 @@ class MainController {
                 return cb({error: "Address is empty"});
             }
 
-            let user = await dbCtrl.getUserByAddress(address);
+            let user = await dbCtrl.getUserByAddress(address, true);
 
             if (user == null) {
                 // ensure that we do not have a race with user creation
@@ -70,7 +70,7 @@ class MainController {
                         // since the outer wasn't mutex-guarded, recheck here with the
                         // mutex. We do not generally want to synchronize all
                         // gets of users!
-                        const recheckedUser = await dbCtrl.getUserByAddress(address);
+                        const recheckedUser = await dbCtrl.getUserByAddress(address, true);
                         if (recheckedUser) {
                             return recheckedUser;
                         }

--- a/models/user.js
+++ b/models/user.js
@@ -35,8 +35,9 @@ export default class User extends BaseModel {
 
     findByAddress(address) {
         return super.get(
-            `SELECT * FROM ${this.tableName} WHERE web3adr = ?`,
-            [address.toLowerCase()]
+            // the descending ordering will give the latest one first...
+            `SELECT * FROM ${this.tableName} WHERE web3adr = ? ORDER BY id DESC`,
+            [address.toString().toLowerCase()]
         );
     }
 }


### PR DESCRIPTION
This is an ugly hack, effectively adding more duplicate users until the code can be more cleanly refactored. The history should remain nevertheless.