### PR TITLE
fix fast confirmations here.

### DIFF
--- a/controller/slaveCtrl.js
+++ b/controller/slaveCtrl.js
@@ -139,7 +139,7 @@ class SlaveCtrl {
         }
 
         const index = this.cosignersArray.indexOf(req.body.walletAddress);
-        const delay = (Math.floor(index / 2) + 1) * 60;
+        const delay = (index + 1) * 60;
 
         res.status(200).json({
             index: index,
@@ -189,7 +189,7 @@ class SlaveCtrl {
 
             // vout can be zero!!!
             if (!btcAdr || !txHash || vout == null) {
-
+                console.error("The requested transaction id %d is not known to master, responding with 404", txId);
                 return res.status(404).json("Error retrieving user payment info");
             }
 

--- a/models/transaction.js
+++ b/models/transaction.js
@@ -42,7 +42,7 @@ export default class Transaction extends BaseModel {
             return res.lastTxId;
         }
         catch (e) {
-            console.log("Failed to fetch last tx id");
+            console.error("Failed to fetch last tx id");
             console.error(e);
             throw e;
         }

--- a/models/transaction.js
+++ b/models/transaction.js
@@ -44,6 +44,7 @@ export default class Transaction extends BaseModel {
         catch (e) {
             console.log("Failed to fetch last tx id");
             console.error(e);
+            throw e;
         }
     }
 

--- a/models/transaction.js
+++ b/models/transaction.js
@@ -35,6 +35,18 @@ export default class Transaction extends BaseModel {
             return null;
         }
     }
+
+    async getLastDepositTxId() {
+        try {
+            const res = await super.get("SELECT max(txId) lastTxId FROM transactions");
+            return res.lastTxId;
+        }
+        catch (e) {
+            console.log("Failed to fetch last tx id");
+            console.error(e);
+        }
+    }
+
     // type should be either 'deposit' or 'tranfer'
     async sumTransacted(type, date) {
         try {


### PR DESCRIPTION
- change the minimal delay back to 1 minute
- respond with 409 (HTTP Conflict) if the txId seems to be beyond the last ID recorded by the master node.